### PR TITLE
Avoid closing ssh when status request fails

### DIFF
--- a/fabfile/fabfile.py
+++ b/fabfile/fabfile.py
@@ -216,7 +216,6 @@ def test_deployment():
             print('waiting to check status ...')
         except Exception as e:
             print("Error : {}".format(e))
-            exit(1)
 
         return response.status_code
     request = 'http://{}/status'.format(env.kirin_host)


### PR DESCRIPTION
This exit was closing ssh so we could run anything on server anymore.