### PR TITLE
refactor deploy

### DIFF
--- a/fabfile/fabfile.py
+++ b/fabfile/fabfile.py
@@ -218,10 +218,10 @@ def test_deployment():
             print("Error : {}".format(e))
 
         return response.status_code
-    request = 'http://{}/status'.format(env.kirin_host)
+    request = 'http://localhost:9090/status'
 
     try:
-        Retrying(stop_max_delay=30000,
+        Retrying(stop_max_delay=5000,
                  wait_fixed=100,
                  retry_on_result=lambda status: check_status(request) != 200)\
             .call(check_status, request)


### PR DESCRIPTION
TODO:

- [ ] test status on localhost, not on vip (not sure this is the right way now)
- [ ] no loop on roles (fabric is supposed to manage it -> to check)
- [ ] upload_template beat only for role beat
- [ ] more robust 'response' in code to avoid "referenced before assignment" ?
- [ ] maybe switch beat to another machine (while releasing or definitely?) : depends if while out of the pool (prod) beat is still publishing and being listened