### PR TITLE
Print status before and after deploy

### DIFF
--- a/fabfile/fabfile.py
+++ b/fabfile/fabfile.py
@@ -138,8 +138,23 @@ def deploy():
     """
     Deploy Kirin services
     """
+    print_status()
     execute(deploy_kirin)
     execute(deploy_kirin_beat)
+    print_status()
+
+
+def print_status():
+
+    request = 'http://{}/status'.format(env.kirin_host)
+    resp = check_node(request)
+    print("")
+    print("curl {}".format(request))
+    if resp:
+        print(resp.json())
+    else:
+        print("[unavailable]")
+    print("")
 
 
 @task()

--- a/fabfile/fabfile.py
+++ b/fabfile/fabfile.py
@@ -28,16 +28,16 @@ class NoSafeDeploymentManager(DeploymentManager):
         """ Null impl """
 
 
-def check_node(query, header=None):
+def check_node(query, headers=None):
     """
     poll on state of execution until it gets a 'succeeded' status
     """
     response = None
     try:
-        if header:
-            response = requests.get(query, headers=header, verify=False)
+        if headers:
+            response = requests.get(query, headers=headers, verify=False)
         else:
-            response = requests.get(query)
+            response = requests.get(query, verify=False)
         print('waiting for enable node ...')
     except Exception as e:
         print("Error : {}".format(e))
@@ -263,13 +263,13 @@ def restart(compose_file):
 def test_deployment():
     """ Verify api kirin is OK """
 
-    header = {'Host': env.kirin_host}
+    headers = {'Host': env.kirin_host}
     request = 'http://{}/status'.format(env.host_string)
 
     try:
         Retrying(stop_max_delay=30000, wait_fixed=100,
                  retry_on_result=lambda resp: resp is None or resp.status_code != 200)\
-            .call(check_node, request, header)
+            .call(check_node, request, headers)
     except Exception as e:
         abort(e)
     print("{} is OK".format(request))

--- a/fabfile/fabfile.py
+++ b/fabfile/fabfile.py
@@ -146,15 +146,24 @@ def deploy():
 
 def print_status():
 
+    def check_and_print_response(query, header=None):
+        response = check_node(query, header)
+        if response is None or response.status_code != 200:
+            return False
+        else:
+            print("")
+            print("curl {}".format(query))
+            print(response.json())
+            print("")
+            return True
+
     request = 'http://{}/status'.format(env.kirin_host)
-    resp = check_node(request)
-    print("")
-    print("curl {}".format(request))
-    if resp:
-        print(resp.json())
-    else:
-        print("[unavailable]")
-    print("")
+    try:
+        Retrying(stop_max_delay=30000, wait_fixed=100,
+                 retry_on_result=lambda res: not res)\
+            .call(check_and_print_response, request)
+    except Exception as e:
+        abort(e)
 
 
 @task()


### PR DESCRIPTION
The goal is to help know what is the situation before and after (version, state, errors...).
Exposes URL usable by anyone (vip used).
Side effect: will probably help db warmup (needed in status), so this may solve the problem of kirin deploy on dev :wink:

:heavy_check_mark: Tested on a job of kirin_deploy_dev https://ci.navitia.io/job/kirin_deploy_dev/475/console
output:
```
curl http://kirin-ws.mutu.dev.canaltp.fr/status
{u'db_version': u'174583a01aea', u'last_update_error': {}, u'last_update': {u'realtime.cots': u'2018-10-12T13:06:34Z', u'realtime.sherbrooke': u'2019-02-15T15:51:59Z', u'realtime.ire': u'2019-02-15T15:51:46Z'}, u'version': u'0.8.0-15-gd371387', u'db_pool_status': u'Pool size: 5  Connections in pool: 1 Current Overflow: -3 Current Checked out connections: 1', u'navitia_url': u'http://navitia2-ws.ctp.dev.canaltp.fr/', u'last_valid_update': {u'realtime.cots': u'2018-10-12T13:06:34Z', u'realtime.sherbrooke': u'2019-02-15T15:51:59Z', u'realtime.ire': u'2019-02-15T15:51:45Z'}, u'rabbitmq_info': {u'transport_options': {}, u'uri_prefix': None, u'login_method': u'AMQPLAIN', u'hostname': u'par-vm147.srv.canaltp.fr', u'userid': u'guest', u'insist': False, u'connect_timeout': 5, u'ssl': False, u'failover_strategy': u'round-robin', u'virtual_host': u'/', u'heartbeat': 180.0, u'password': u'guest', u'port': 5672, u'transport': u'amqp', u'alternates': []}}
```