### PR TITLE
Add cots_contributor in env file

### DIFF
--- a/fabfile/templates/kirin.env
+++ b/fabfile/templates/kirin.env
@@ -2,6 +2,7 @@ KIRIN_SQLALCHEMY_DATABASE_URI=postgresql://{{env.user_kirin_postgres}}:{{env.pwd
 KIRIN_NAVITIA_URL={{env.navitia_url}}
 KIRIN_NAVITIA_TOKEN={{env.navitia_token}}
 KIRIN_NAVITIA_INSTANCE={{env.navitia_instance}}
+KIRIN_COTS_CONTRIBUTOR={{env.cots_contributor}}
 KIRIN_COTS_PAR_IV_API_KEY={{env.cots_par_iv_api_key}}
 KIRIN_COTS_PAR_IV_MOTIF_RESOURCE_SERVER={{env.cots_par_iv_motif_resource_server}}
 KIRIN_COTS_PAR_IV_TOKEN_SERVER={{env.cots_par_iv_token_server}}


### PR DESCRIPTION
This parameter is absent in env file and so never used in configuration file. We used default value 'realtime.cots' from parameter declaration :  COTS_CONTRIBUTOR = os.getenv("KIRIN_COTS_CONTRIBUTOR", "realtime.cots")

https://jira.kisio.org/browse/NAVP-1439