### PR TITLE
Split up kirin port for host and docker.

### DIFF
--- a/fabfile/templates/docker-compose_kirin.yml
+++ b/fabfile/templates/docker-compose_kirin.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
   kirin:
     ports:
-     - "{{env.kirin_port}}:{{env.kirin_port}}"
+     - "{{env.kirin_host_port}}:{{env.kirin_docker_port}}"
     image: {{env.docker_image_kirin}}:{{env.current_docker_tag}}
     restart: always
 {% if env.use_syslog %}


### PR DESCRIPTION
Because kirin is behind a reverse proxy on some environments, we need to
configure different port depending on the situation.

 - [ ] requires - https://github.com/CanalTP/kirin_deployment_conf/pull/42