### PR TITLE
Allow a change of KIRIN_POLLER_MIN_INTERVAL by plateform

### DIFF
--- a/fabfile/templates/kirin.env
+++ b/fabfile/templates/kirin.env
@@ -26,6 +26,10 @@ KIRIN_CELERY_BROKER_URL={{env.celery_broker_url}}
 KIRIN_RABBITMQ_CONNECTION_STRING=pyamqp://{{env.user_rabbitmq}}:{{env.pwd_rabbitmq}}@{{env.rabbitmq_url}}:5672//?heartbeat={{env.heartbeat_rabbitmq}}
 KIRIN_LOG_FORMAT=[%(asctime)s] [%(levelname)5s] [%(process)5s] [%(name)25s - kirin_{{env.name}}] %(message)s
 
+{% if env.poller_min_interval is defined %}
+KIRIN_POLLER_MIN_INTERVAL = {{env.poller_min_interval}}
+{% endif %}
+
 {% if env.new_relic_key %}
 KIRIN_NEW_RELIC_CONFIG_FILE=/usr/src/app/newrelic.ini
 {% endif %}


### PR DESCRIPTION
That was just added into Kirin, defaults to 10s there : https://github.com/CanalTP/kirin/pull/288
So no complementary work planned as 10s is the target for now on all PF.

JIRA: https://jira.kisio.org/browse/NDTMA-76 (see comments)