### PR TITLE
Allow rabbitmq vhost for kirin2nav output

### DIFF
--- a/fabfile/templates/kirin.env
+++ b/fabfile/templates/kirin.env
@@ -23,7 +23,7 @@ KIRIN_REDIS_DB={{env.redis_db}}
 KIRIN_REDIS_PORT={{env.redis_port}}
 KIRIN_REDIS_PASSWORD={{env.redis_password}}
 KIRIN_CELERY_BROKER_URL={{env.celery_broker_url}}
-KIRIN_RABBITMQ_CONNECTION_STRING=pyamqp://{{env.user_rabbitmq}}:{{env.pwd_rabbitmq}}@{{env.rabbitmq_url}}:5672//?heartbeat={{env.heartbeat_rabbitmq}}
+KIRIN_RABBITMQ_CONNECTION_STRING=pyamqp://{{env.user_rabbitmq}}:{{env.pwd_rabbitmq}}@{{env.rabbitmq_url}}:5672/{{env.rabbitmq_vhost}}?heartbeat={{env.heartbeat_rabbitmq}}
 KIRIN_LOG_FORMAT=[%(asctime)s] [%(levelname)5s] [%(process)5s] [%(name)25s - kirin_{{env.name}}] %(message)s
 
 {% if env.poller_min_interval is defined %}


### PR DESCRIPTION
TODO:
- [x] merge default vhost value into deployment_conf https://github.com/CanalTP/kirin_deployment_conf/pull/49