### PR TITLE
Restart-safety: rm celerybeat pidfile before start

### DIFF
--- a/fabfile/templates/docker-compose_kirin-beat.yml
+++ b/fabfile/templates/docker-compose_kirin-beat.yml
@@ -5,7 +5,7 @@ services:
   kirin_beat:
     image: {{env.docker_image_kirin}}:{{env.current_docker_tag}}
     restart: always
-    command: celery beat -A kirin.tasks.celery
+    command: sh -c "rm -f /tmp/kirin-celerybeat.pid ; celery beat -A kirin.tasks.celery --pidfile=/tmp/kirin-celerybeat.pid"
 {% if env.use_syslog %}
     logging:
       driver: "syslog"


### PR DESCRIPTION
Bug fixed (seen on test platforms) :
1. docker service (or host) crashes for any other reason
2. docker is restarted, so kirin-beat container too
3. kirin-beat container stays "Restarting" as the pidfile exists, and a process with the given PID runs so it prevents celerybeat from starting
4. workers don't get any work

Moved the pidfile to a more "unique" and safe place on the way.
