### PR TITLE
[>=Kirin4.1] Add piv-worker component to deploy

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,4 +1,5 @@
 # fab_kirin local demo
+
 Deploy kirin locally
 
 The goal is to showcase local deployment of Kirin using mostly the same mechanism
@@ -19,28 +20,34 @@ Make sure that user `navitia` has read/write access to RabbitMQ's vhost used by
 Kraken (`/` in current conf)
 
 Create a workspace for fab_kirin:
+
 ```bash
 mkdir -p ~/fab_kirin_workspace                # matching 'env.path' in local_dockerized_deps
 mkdir -p ~/fab_kirin_workspace/postgres-data  # matching 'kirin_db' volume mounted in docker-compose_deps.yml
 ```
 
 Install python dependencies (using a virtualenv is recommended) with:
+
 ```bash
 cd /path/to/fab_kirin
 pip install -r requirements.txt -U
 ```
 
 Create and run containers for dependencies:
+
 ```bash
 docker-compose -f demo/deps/docker-compose_deps.yml up -d
 ```
 
 For a first-time deployment:
+
 ```bash
 PYTHONPATH=demo/conf fab use:local_dockerized_deps deploy:first_time=True
+# During process, you should be asked a ssh password and then a session password to localhost.
 ```
 
 You should now be able to request successfully (everything should be OK):
+
 ```bash
 curl localhost:54746/status
 ```

--- a/fabfile/templates/docker-compose_kirin.yml
+++ b/fabfile/templates/docker-compose_kirin.yml
@@ -20,7 +20,7 @@ services:
       KIRIN_USE_GEVENT: 'true'
 {% if env.new_relic_key %}
     volumes:
-        - {{env.path}}/newrelic.ini:/usr/src/app/newrelic.ini
+      - {{env.path}}/newrelic.ini:/usr/src/app/newrelic.ini
 {% endif %}
 
   kirin_background:
@@ -40,7 +40,7 @@ services:
       KIRIN_USE_GEVENT: 'true'
 {% if env.new_relic_key %}
     volumes:
-        - {{env.path}}/newrelic.ini:/usr/src/app/newrelic.ini
+      - {{env.path}}/newrelic.ini:/usr/src/app/newrelic.ini
 {% endif %}
 
   kirin_worker:
@@ -58,7 +58,27 @@ services:
     env_file: kirin.env
 {% if env.new_relic_key %}
     volumes:
-        - {{env.path}}/newrelic.ini:/usr/src/app/newrelic.ini
+      - {{env.path}}/newrelic.ini:/usr/src/app/newrelic.ini
+{% endif %}
+
+  kirin_piv_worker:
+    image: {{env.docker_image_kirin}}:{{env.current_docker_tag}}
+    restart: always
+    command: python ./manage.py piv_worker
+{% if env.use_syslog %}
+    logging:
+      driver: "syslog"
+      options:
+        syslog-address: "{{env.protocole_syslog}}://{{env.host_syslog}}:{{env.port_syslog}}"
+        syslog-facility: "local7"
+        tag: "kirin-piv-worker"
+{% endif %}
+    env_file: kirin.env
+    environment:
+      KIRIN_USE_GEVENT: 'true'
+{% if env.new_relic_key %}
+    volumes:
+      - {{env.path}}/newrelic.ini:/usr/src/app/newrelic.ini
 {% endif %}
 
 {% if env.docker_network %}

--- a/fabfile/templates/kirin.env
+++ b/fabfile/templates/kirin.env
@@ -26,6 +26,10 @@ KIRIN_CELERY_BROKER_URL={{env.celery_broker_url}}
 KIRIN_RABBITMQ_CONNECTION_STRING=pyamqp://{{env.user_rabbitmq}}:{{env.pwd_rabbitmq}}@{{env.rabbitmq_url}}:{{env.rabbitmq_port|default(5672)}}/{{env.rabbitmq_vhost}}?heartbeat={{env.heartbeat_rabbitmq}}
 KIRIN_LOG_FORMAT=[%(asctime)s] [%(levelname)5s] [%(process)5s] [%(name)25s - kirin_{{env.name}}] %(message)s
 
+{% if env.broker_consumer_configuration_reload_interval is defined %}
+KIRIN_BROKER_CONSUMER_CONFIGURATION_RELOAD_INTERVAL = {{env.broker_consumer_configuration_reload_interval}}
+{% endif %}
+
 {% if env.poller_min_interval is defined %}
 KIRIN_POLLER_MIN_INTERVAL = {{env.poller_min_interval}}
 {% endif %}


### PR DESCRIPTION
Hand-tested locally that it works (no tests on this repo).

This requires Kirin to have PIV-worker available, so strictly above version `4.0.x`.
We could also add a feature-trigger (not necessary IMO).

TODO:
- [x] wait to really need this for dev platform deployment (or for a >=4.1 release)

JIRA: https://jira.kisio.org/browse/ND-1049