### PR TITLE
[tech] filter errors that are OK technically

### DIFF
--- a/fabfile/templates/newrelic.ini
+++ b/fabfile/templates/newrelic.ini
@@ -164,8 +164,8 @@ error_collector.enabled = true
 
 # To stop specific errors from reporting to the UI, set this to
 # a space separated list of the Python exception type names to
-# ignore. The exception name should be of the form 'module:class'.
-error_collector.ignore_errors =
+# ignore. The exception name should be of the form 'module.submodule:class'.
+error_collector.ignore_errors = navitia_wrapper::NavitiaException werkzeug.exceptions:NotFound werkzeug.exceptions:MethodNotAllowed kirin.exceptions:UnsupportedValue kirin.exceptions:ObjectNotFound kirin.exceptions:InvalidArguments
 
 # Browser monitoring is the Real User Monitoring feature of the UI.
 # For those Python web frameworks that are supported, this


### PR DESCRIPTION
After https://github.com/CanalTP/kirin/pull/361
Exceptions that are only functional are filtered in newrelic.ini file.

(it doesn't seem possible to split line in `.ini` file: https://stackoverflow.com/a/29194027)

JIRA: https://jira.kisio.org/browse/ND-841