### PR TITLE
add a Dockerfile as a context for using fabric

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,3 @@ RUN mkdir /fabfile
 COPY fabfile /fabfile
 WORKDIR /fabfile
 ENV PYTHONPYCACHEPREFIX=/tmp
-
-ENTRYPOINT [ "fab" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,9 @@ RUN BUILD_DEPENDENCIES="apt-transport-https curl gnupg-agent software-properties
 COPY requirements.txt /
 RUN pip install -r /requirements.txt -U
 
-# set current workspace in PythonPath to be able to find later configuration files
-ENV PYTHONPATH=.
-
 # setup kirin fabric
 RUN mkdir /fabfile
 COPY fabfile /fabfile
-RUN echo "fabfile = /fabfile/fabfile.py" > ~/.fabricrc
+WORKDIR /fabfile
 
 ENTRYPOINT [ "fab" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.9.1-slim
 
 # add docker cli
 ARG DOCKER_VERSION="5:19.03.13~3-0~debian-buster"
-RUN BUILD_DEPENDENCIES="apt-transport-https ca-certificates curl gnupg-agent software-properties-common" \
+RUN BUILD_DEPENDENCIES="apt-transport-https curl gnupg-agent software-properties-common" \
 	&& apt update \
-	&& apt install --yes ${BUILD_DEPENDENCIES} \
+	&& apt install --yes ca-certificates ${BUILD_DEPENDENCIES} \
 	&& curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add \
 	&& add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
 	&& apt update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.9.1-slim
 
 # add docker cli
 ARG DOCKER_VERSION="5:19.03.13~3-0~debian-buster"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3-slim
+
+# add docker cli
+ARG DOCKER_VERSION="5:19.03.13~3-0~debian-buster"
+RUN BUILD_DEPENDENCIES="apt-transport-https ca-certificates curl gnupg-agent software-properties-common" \
+	&& apt update \
+	&& apt install --yes ${BUILD_DEPENDENCIES} \
+	&& curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add \
+	&& add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+	&& apt update \
+	&& apt -y install docker-ce-cli=${DOCKER_VERSION} \
+	&& apt -y purge ${BUILD_DEPENDENCIES} \
+	&& apt autoremove --yes \
+	&& rm -rf /var/lib/apt/lists/*
+
+# install dependencies for kirin fabric
+COPY requirements.txt /
+RUN pip install -r /requirements.txt -U
+
+# set current workspace in PythonPath to be able to find later configuration files
+ENV PYTHONPATH=.
+
+# setup kirin fabric
+RUN mkdir /fabfile
+COPY fabfile /fabfile
+RUN echo "fabfile = /fabfile/fabfile.py" > ~/.fabricrc
+
+ENTRYPOINT [ "fab" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,6 @@ RUN pip install -r /requirements.txt -U
 RUN mkdir /fabfile
 COPY fabfile /fabfile
 WORKDIR /fabfile
+ENV PYTHONPYCACHEPREFIX=/tmp
 
 ENTRYPOINT [ "fab" ]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Same principle as above for `fabric` usage, but this is an example to focus on s
 docker run --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "/path/to/folder/containing/kirin/<platform_file_name>.py:/kirin_conf" --workdir "/kirin_conf" navitia/fab_kirin use:<platform_file_name> deploy
 ```
 
-The Docker socket is required since few Docker commands are run by `fabric`.
+The Docker socket is required since some Docker commands are run by `fabric`.
 
 The other volume is used to share `<platform_file_name>.py`. The `workdir` option must be set to the same value than the target of the shared volume to make the `<platform_file_name>.py` reachable by `fabric`.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Same principle as above for `fabric` usage, but this is an example to focus on s
 docker run --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "/path/to/folder/containing/kirin_conf/<platform_file_name>.py:/kirin_conf" --env "PYTHONPATH=/kirin_conf" navitia/fab_kirin fab use:<platform_file_name> deploy
 ```
 
-The Docker socket is required since some Docker commands are run by `fabric`.
+The binding of the Docker socket is required since some Docker commands are run by `fabric`.
 
 The `kirin_conf` volume is used to share `<platform_file_name>.py`. The `PYTHONPATH` environment variable must be set to the same value than the target of the shared volume to make the `<platform_file_name>.py` reachable by `fabric`.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Kirin's deployment mechanisms
 
 ## Invocation
 
+### from source code with a working setup
+
 For a regular deployment (on a platform with Kirin already running):
 ```bash
 PYTHONPATH=/path/to/kirin_deployment_conf/ fab use:<platform_file_name> deploy
@@ -12,6 +14,18 @@ For a first-time deployment on an empty platform:
 ```bash
 PYTHONPATH=/path/to/kirin_deployment_conf/ fab use:<platform_file_name> deploy:first_time=True
 ```
+
+### using Docker image
+
+Same principle as above for `fabric` usage, but this is an example to focus on specific options to use for Docker:
+
+``` bash
+docker run --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "/path/to/folder/containing/kirin/<platform_file_name>.py:/kirin_conf" --workdir "/kirin_conf" navitia/fab_kirin use:<platform_file_name> deploy
+```
+
+The Docker socket is required since few Docker commands are run by `fabric`.
+
+The other volume is used to share `<platform_file_name>.py`. The `workdir` option must be set to the same value than the target of the shared volume to make the `<platform_file_name>.py` reachable by `fabric`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ PYTHONPATH=/path/to/kirin_deployment_conf/ fab use:<platform_file_name> deploy:f
 Same principle as above for `fabric` usage, but this is an example to focus on specific options to use for Docker:
 
 ``` bash
-docker run --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "/path/to/folder/containing/kirin/<platform_file_name>.py:/kirin_conf" --workdir "/kirin_conf" navitia/fab_kirin use:<platform_file_name> deploy
+docker run --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "/path/to/folder/containing/kirin_conf/<platform_file_name>.py:/kirin_conf" --env "PYTHONPATH=/kirin_conf" navitia/fab_kirin use:<platform_file_name> deploy
 ```
 
 The Docker socket is required since some Docker commands are run by `fabric`.
 
-The `kirin_conf` volume is used to share `<platform_file_name>.py`. The `workdir` option must be set to the same value than the target of the shared volume to make the `<platform_file_name>.py` reachable by `fabric`.
+The `kirin_conf` volume is used to share `<platform_file_name>.py`. The `PYTHONPATH` environment variable must be set to the same value than the target of the shared volume to make the `<platform_file_name>.py` reachable by `fabric`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ PYTHONPATH=/path/to/kirin_deployment_conf/ fab use:<platform_file_name> deploy:f
 Same principle as above for `fabric` usage, but this is an example to focus on specific options to use for Docker:
 
 ``` bash
-docker run --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "/path/to/folder/containing/kirin_conf/<platform_file_name>.py:/kirin_conf" --env "PYTHONPATH=/kirin_conf" navitia/fab_kirin use:<platform_file_name> deploy
+docker run --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "/path/to/folder/containing/kirin_conf/<platform_file_name>.py:/kirin_conf" --env "PYTHONPATH=/kirin_conf" navitia/fab_kirin fab use:<platform_file_name> deploy
 ```
 
 The Docker socket is required since some Docker commands are run by `fabric`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker run --volume "/var/run/docker.sock:/var/run/docker.sock" --volume "/path/
 
 The Docker socket is required since some Docker commands are run by `fabric`.
 
-The other volume is used to share `<platform_file_name>.py`. The `workdir` option must be set to the same value than the target of the shared volume to make the `<platform_file_name>.py` reachable by `fabric`.
+The `kirin_conf` volume is used to share `<platform_file_name>.py`. The `workdir` option must be set to the same value than the target of the shared volume to make the `<platform_file_name>.py` reachable by `fabric`.
 
 ## Usage
 


### PR DESCRIPTION
This image is aimed to be pushed to Docker Hub with the name `navitia/fab_kirin` (to be consistent with the README).

The purpose is to offer a context for using this `fabric` file without any assumptions on the machine which is running `fabric` (unless `docker` must be installed).